### PR TITLE
Misspelling in clear-log command

### DIFF
--- a/src/Modules/Prompt/Dnn.PersonaBar.Prompt/Commands/Portal/ClearLog.cs
+++ b/src/Modules/Prompt/Dnn.PersonaBar.Prompt/Commands/Portal/ClearLog.cs
@@ -10,7 +10,7 @@ using System;
 
 namespace Dnn.PersonaBar.Prompt.Commands.Host
 {
-    [ConsoleCommand("clear-log", "Clears the Event Logo for the current portal", new string[] {})]
+    [ConsoleCommand("clear-log", "Clears the Event Log for the current portal", new string[] {})]
     public class ClearLog : ConsoleCommandBase, IConsoleCommand
 {
 


### PR DESCRIPTION
"Clears the Event Logo for the current portal" should be "Clears the Event Log for the current portal".  Resolves #73 